### PR TITLE
Fix selector for mic button

### DIFF
--- a/src/content_script.ts
+++ b/src/content_script.ts
@@ -14,7 +14,7 @@ setInterval(() => findMicButton(), 250);
 
 function findMicButton() {
     document.querySelectorAll('[data-tooltip]').forEach((element: HTMLElement) => {
-        if (element.dataset.tooltip && (element.dataset.tooltip.includes('⌘ + D') || element.dataset.tooltip.includes('CTRL + D'))) {
+        if (element.dataset.tooltip && (element.dataset.tooltip.toLowerCase().includes('⌘ + d') || element.dataset.tooltip.toLowerCase().includes('ctrl + d'))) {
             if (micButton !== element) {
                 micButton = element;
                 listenForMicButtonClick();


### PR DESCRIPTION
Google apparently changed the tooltip to use a lowercase D and since the selector was case sensitive, the push-to-talk wasn't working. This fixes that.