### PR TITLE
Support more languages

### DIFF
--- a/src/content_script.ts
+++ b/src/content_script.ts
@@ -14,8 +14,12 @@ function listenForMicButtonClick() {
 setInterval(() => findMicButton(), 250);
 
 function findMicButton() {
+    // German has a different name for the ctrl key
+    // French has no spaces around the plus
+    // Japanese uses fullwidth parentheses and has additional text
+    const muteButtonTooltip = /\((?:ctrl|strg) ?\+ ?d\)|\uFF08ctrl\+d.*\uFF09/i
     document.querySelectorAll('[data-tooltip]').forEach((element: HTMLElement) => {
-        if (element.dataset.tooltip && (element.dataset.tooltip.toLowerCase().includes('⌘ + d') || element.dataset.tooltip.toLowerCase().includes('ctrl + d'))) {
+        if (element.dataset.tooltip && muteButtonTooltip.test(element.dataset.tooltip)) {
             if (micButton !== element) {
                 micButton = element;
                 listenForMicButtonClick();


### PR DESCRIPTION
When the Google account is set to a non-english language, the keyboard shortcut isn't always `ctrl + d`, but a localized version of that.
This change switches to a regular expression for matching the tooltip and should work with most languages.

Tested with:
| Language | Tooltip                           |
|----------|-----------------------------------|
| en       | Turn off microphone (ctrl + d)    |
| de       | Mikrofon deaktivieren (Strg + d)  |
| fr       | Désactiver le micro (Ctrl+d)      |
| ar       | إيقاف الميكروفون (ctrl + d)       |
| jp       | マイクをオフにする（Ctrl+D キー） |
| zh       | 关闭麦克风 (ctrl + d)             |
| kr       | 마이크 끄기(ctrl + d)             |